### PR TITLE
CVE-2017-14633: Add check so we abort on too many channels

### DIFF
--- a/examples/encoder_example.c
+++ b/examples/encoder_example.c
@@ -1735,7 +1735,8 @@ int main(int argc,char *argv[]){
       ogg_packet header;
       ogg_packet header_comm;
       ogg_packet header_code;
-      vorbis_analysis_headerout(&vd,&vc,&header,&header_comm,&header_code);
+      if (vorbis_analysis_headerout(&vd,&vc,&header,&header_comm,&header_code) < 0)
+        exit(1);
       ogg_stream_packetin(&vo,&header); /* automatically placed in its own
                                            page */
       if(ogg_stream_pageout(&vo,&og)!=1){


### PR DESCRIPTION
This makes sure we abort encoding in case https://github.com/xiph/vorbis/pull/34 gets applied.