### PR TITLE
Make sure libtheoraenc do not need libtheoradec

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -139,6 +139,7 @@ encoder_sources = \
 	dequant.c \
 	fragment.c \
 	idct.c \
+	info.c \
 	internal.c \
 	state.c \
 	quant.c \
@@ -260,7 +261,6 @@ libtheoraenc_la_LDFLAGS = \
   -version-info @THENC_LIB_CURRENT@:@THENC_LIB_REVISION@:@THENC_LIB_AGE@ \
   @THEORAENC_LDFLAGS@ $(OGG_LIBS) \
   -no-undefined
-libtheoraenc_la_LIBADD = libtheoradec.la
 
 libtheora_la_SOURCES = \
 	$(decoder_sources) \


### PR DESCRIPTION
Addresses issue reported in https://bugs.debian.org/923940 about some symbols being unresolved.