### PR TITLE
Use Python 3 compatible print function in SConstruct

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -110,11 +110,11 @@ conf = Configure(env, custom_tests = {
   })
   
 if not conf.CheckPKGConfig('0.15.0'): 
-   print 'pkg-config >= 0.15.0 not found.' 
+   print('pkg-config >= 0.15.0 not found.')
    Exit(1)
 
 if not conf.CheckPKG('ogg'): 
-  print 'libogg not found.' 
+  print('libogg not found.')
   Exit(1) 
 
 if conf.CheckPKG('vorbis vorbisenc'):


### PR DESCRIPTION
Works on macOS 10.15 with SCons installed from Homebrew.