### PR TITLE
remove redundant assignments

### DIFF
--- a/lib/tokenize.c
+++ b/lib/tokenize.c
@@ -487,11 +487,11 @@ int oc_enc_tokenize_ac(oc_enc_ctx *_enc,int _pli,ptrdiff_t _fragi,
   zzj=64;
   for(zzi=OC_MINI(_zzi,63);zzi>0;zzi--){
     ogg_uint32_t best_cost;
-    int          best_bits=best_bits;
-    int          best_next=best_next;
-    int          best_token=best_token;
-    int          best_eb=best_eb;
-    int          best_qc=best_qc;
+    int          best_bits;
+    int          best_next;
+    int          best_token;
+    int          best_eb;
+    int          best_qc;
     ogg_uint32_t d2;
     int          dq;
     int          qc_m;
@@ -1091,8 +1091,8 @@ void oc_enc_tokenize_dc_frag_list(oc_enc_ctx *_enc,int _pli,
   int                neobs1;
   int                token;
   int                eb;
-  int                token1=token1;
-  int                eb1=eb1;
+  int                token1;
+  int                eb1;
   /*Return immediately if there are no coded fragments; otherwise we'd flush
      any trailing EOB run into the AC 1 list and never read it back out.*/
   if(_ncoded_fragis<=0)return;
@@ -1328,7 +1328,7 @@ void oc_enc_tokenize_finish(oc_enc_ctx *_enc){
     int       new_eb;
     int       zzj;
     int       plj;
-    ptrdiff_t ti=ti;
+    ptrdiff_t ti;
     int       run_count;
     /*Make sure this coefficient has tokens at all.*/
     if(_enc->ndct_tokens[pli][zzi]<=0)continue;


### PR DESCRIPTION
Currently, the windows msvc debug build of theora will crash due to the compiler identifying the use of uninitialized memory. These crashes can be traced back to some redundant assignments in the source code. This patch removes those assignments, fixing the problem. The patch has been carried downstream in vcpkg for some time: https://github.com/microsoft/vcpkg/blob/1a07422d3dd3e58f1d2eb132d0e54fbf82f1ac48/ports/libtheora/0001-fix-uwp.patch