### PR TITLE
Add support for the \texttrademark character to avoid encoding errors

### DIFF
--- a/doc/spec/spec.tex
+++ b/doc/spec/spec.tex
@@ -14,6 +14,7 @@
 \usepackage{float}
 \usepackage[pdfpagemode=None,pdfstartview=FitH,pdfview=FitH,colorlinks=true]%
  {hyperref}
+\usepackage{utf8x}[inputenc]
 
 \newtheorem{theorem}{Theorem}[section]
 \newcommand{\idx}[1]{{\ensuremath{\mathit{#1}}}}


### PR DESCRIPTION
This solution fix build error with spack:  [spack issue](https://github.com/spack/spack/issues/19312).