### PR TITLE
Fix the runtime error: shift exponent -1 is negative in huffdec.c

### DIFF
--- a/lib/huffdec.c
+++ b/lib/huffdec.c
@@ -225,7 +225,11 @@ int oc_huff_tree_unpack(oc_pack_buf *_opb,unsigned char _tokens[256][2]){
         _tokens[ntokens][1]=(unsigned char)(len+neb);
         ntokens++;
       }
-      code_bit=0x80000000U>>len-1;
+      if (len > 0) {
+        code_bit = 0x80000000U >> (len - 1);
+      } else {
+        return TH_EBADHEADER;
+      }  
       while(len>0&&(code&code_bit)){
         code^=code_bit;
         code_bit<<=1;


### PR DESCRIPTION
When calling the function th_decode_ceaderin through constructed data, it will cause the len value in the oc_fuff_tree_unpack function to be 0 when subsequent functions run, resulting in the problem of negative displacement. This modification is to avoid len being negative

huffdec.c:228:27: runtime error: shift exponent -1 is negative
    #0 0x5d471012bfd0 in oc_huff_tree_unpack /home/uos/libtheora-18570/theora/lib/huffdec.c:228
    #1 0x5d471012c134 in oc_huff_trees_unpack /home/uos/libtheora-18570/theora/lib/huffdec.c:392
    #2 0x5d471010a98c in oc_setup_unpack /home/uos/libtheora-18570/theora/lib/decinfo.c:169
    #3 0x5d471010a98c in oc_dec_headerin /home/uos/libtheora-18570/theora/lib/decinfo.c:238
    #4 0x5d471010a98c in th_decode_headerin /home/uos/libtheora-18570/theora/lib/decinfo.c:266
    #5 0x5d47100fd638 in TheoraDecoder::initialize() /home/uos/libtheora-18570/libtheora-18570/fuzzer.cpp:66
    #6 0x5d47100ffa76 in TheoraDecoder::Run() /home/uos/libtheora-18570/libtheora-18570/fuzzer.cpp:180
    #7 0x5d47100ffe48 in main /home/uos/libtheora-18570/libtheora-18570/fuzzer.cpp:240
    #8 0x7cc9a5e29d8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #9 0x7cc9a5e29e3f in __libc_start_main_impl ../csu/libc-start.c:392
    #10 0x5d47100f9964 in _start (/home/uos/libtheora-18570/libtheora-18570/poc1+0x83964)