### PR TITLE
ci: pin actions/checkout to full commit SHA and add read-only permissions

### DIFF
--- a/.github/workflows/autotools.yml
+++ b/.github/workflows/autotools.yml
@@ -6,6 +6,8 @@ on:
   schedule:
     - cron: '0 0 1 * *'
 
+permissions: read-all
+
 jobs:
   build:
     strategy:
@@ -19,7 +21,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install macOS dependencies
         if: startsWith(matrix.os,'macos')


### PR DESCRIPTION
## Summary

`autotools.yml` lacked a `permissions:` block and used the mutable `actions/checkout@v2` tag.

This patch adds `permissions: read-all` at the workflow level and pins `actions/checkout` to the full commit SHA of the current v6.0.3 release, preventing silent tag-rewriting supply-chain attacks.

## Verification

```
uvx zizmor --min-severity high .github/workflows/
```
Result: **no findings** after this patch.